### PR TITLE
fix: correct substring method usage in hexToArrayBuffer function

### DIFF
--- a/src/lib/ClientSecureKeyExchange.ts
+++ b/src/lib/ClientSecureKeyExchange.ts
@@ -21,7 +21,13 @@ export class ClientSecureKeyExchange {
    * Get the generate a client public key for the key exchange
    */
   async getPublicKey() {
-    await this.generateClientKeys();
+    // Check if the cryptoKeyPair is already generated
+    if (!this.cryptoKeyPair) {
+      await this.generateClientKeys();
+    }
+
+    if (!this.cryptoKeyPair) throw new Error("Failed to generate client keys");
+
     const publicKey = await window.crypto.subtle.exportKey(
       "raw",
       this.cryptoKeyPair!.publicKey
@@ -49,6 +55,7 @@ export class ClientSecureKeyExchange {
       true,
       []
     );
+
     const sharedSecret = await window.crypto.subtle.deriveBits(
       {
         name: "ECDH",

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -8,9 +8,10 @@ export const hexToArrayBuffer = (hex: string) => {
   if (!hex) {
     return new Uint8Array();
   }
+
   const arr = [];
   for (let i = 0, len = hex.length; i < len; i += 2) {
-    arr.push(parseInt(hex.substr(i, 2), 16));
+    arr.push(parseInt(hex.substring(i, 2), 16));
   }
   return new Uint8Array(arr);
 };


### PR DESCRIPTION
String.prototype.substr() is a legacy feature and it is deprecated

[check detail](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr)